### PR TITLE
fix(examples): provide examples for Render, Compact and Pretty functions

### DIFF
--- a/compact_example_test.go
+++ b/compact_example_test.go
@@ -1,0 +1,246 @@
+package render_test
+
+import (
+	"encoding/xml"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/jimeh/go-render"
+)
+
+//nolint:lll
+func ExampleCompact_json() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Compact(os.Stdout, "json", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// {"current":"1.2.2","versions":[{"version":"1.2.2","latest":true,"stable":true},{"version":"1.2.1","latest":false,"stable":true},{"version":"1.2.0","latest":false,"stable":true},{"version":"1.2.0-rc.0","latest":false,"stable":false},{"version":"1.1.0","latest":false,"stable":true}]}
+}
+
+func ExampleCompact_yaml() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Compact(os.Stdout, "yaml", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// current: 1.2.2
+	// versions:
+	//   - version: 1.2.2
+	//     latest: true
+	//     stable: true
+	//   - version: 1.2.1
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0-rc.0
+	//     latest: false
+	//     stable: false
+	//   - version: 1.1.0
+	//     latest: false
+	//     stable: true
+}
+
+//nolint:lll
+func ExampleCompact_xml() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	// Create a new renderer that supports XML in addition to the default JSON,
+	// Text, and YAML formats.
+	renderer := render.NewWith("json", "text", "xml", "yaml")
+
+	err := renderer.Compact(os.Stdout, "xml", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// <versions-list><current>1.2.2</current><version latest="true" stable="true">1.2.2</version><version latest="false" stable="true">1.2.1</version><version latest="false" stable="true">1.2.0</version><version latest="false" stable="false">1.2.0-rc.0</version><version latest="false" stable="true">1.1.0</version></versions-list>
+}
+
+func ExampleCompact_textFromByteSlice() {
+	data := []byte("Hello, World!1")
+
+	err := render.Compact(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!1
+}
+
+func ExampleCompact_textFromString() {
+	data := "Hello, World!"
+
+	err := render.Compact(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!
+}
+
+func ExampleCompact_textFromIOReader() {
+	var data io.Reader = strings.NewReader("Hello, World!!!1")
+
+	err := render.Compact(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!!!1
+}
+
+func ExampleCompact_textFromWriterTo() {
+	// The Version struct has a WriteTo method which writes a string
+	// representation of a version to an io.Writer:
+	//
+	//	func (v *Version) WriteTo(w io.Writer) (int64, error) {
+	//		s := fmt.Sprintf(
+	//			"%s (stable: %t, latest: %t)", v.Version, v.Stable, v.Latest,
+	//		)
+	//		n, err := w.Write([]byte(s))
+	//
+	//		return int64(n), err
+	//	}
+
+	data := &Version{Version: "1.2.1", Stable: true, Latest: false}
+
+	err := render.Compact(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1.2.1 (stable: true, latest: false)
+}
+
+func ExampleCompact_textFromStringer() {
+	// The User struct has a String method which returns a string representation
+	// of a user:
+	//
+	//	func (ol *OutputList) String() string {
+	//		buf := &strings.Builder{}
+	//
+	//		for _, ver := range ol.Versions {
+	//			if ol.Current == ver.Version {
+	//				buf.WriteString("* ")
+	//			} else {
+	//				buf.WriteString("  ")
+	//			}
+	//
+	//			buf.WriteString(ver.Version)
+	//			if !ver.Stable {
+	//				buf.WriteString(" (pre-release)")
+	//			}
+	//			if ver.Latest {
+	//				buf.WriteString(" (latest)")
+	//			}
+	//
+	//			buf.WriteByte('\n')
+	//		}
+	//
+	//		return buf.String()
+	//	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Compact(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// * 1.2.2 (latest)
+	//   1.2.1
+	//   1.2.0
+	//   1.2.0-rc.0 (pre-release)
+	//   1.1.0
+}

--- a/pretty_example_test.go
+++ b/pretty_example_test.go
@@ -1,0 +1,280 @@
+package render_test
+
+import (
+	"encoding/xml"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/jimeh/go-render"
+)
+
+func ExamplePretty_json() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Pretty(os.Stdout, "json", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// {
+	//   "current": "1.2.2",
+	//   "versions": [
+	//     {
+	//       "version": "1.2.2",
+	//       "latest": true,
+	//       "stable": true
+	//     },
+	//     {
+	//       "version": "1.2.1",
+	//       "latest": false,
+	//       "stable": true
+	//     },
+	//     {
+	//       "version": "1.2.0",
+	//       "latest": false,
+	//       "stable": true
+	//     },
+	//     {
+	//       "version": "1.2.0-rc.0",
+	//       "latest": false,
+	//       "stable": false
+	//     },
+	//     {
+	//       "version": "1.1.0",
+	//       "latest": false,
+	//       "stable": true
+	//     }
+	//   ]
+	// }
+}
+
+func ExamplePretty_yaml() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Pretty(os.Stdout, "yaml", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// current: 1.2.2
+	// versions:
+	//   - version: 1.2.2
+	//     latest: true
+	//     stable: true
+	//   - version: 1.2.1
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0-rc.0
+	//     latest: false
+	//     stable: false
+	//   - version: 1.1.0
+	//     latest: false
+	//     stable: true
+}
+
+func ExamplePretty_xml() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	// Create a new renderer that supports XML in addition to the default JSON,
+	// Text, and YAML formats.
+	renderer := render.NewWith("json", "text", "xml", "yaml")
+
+	err := renderer.Pretty(os.Stdout, "xml", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// <versions-list>
+	//   <current>1.2.2</current>
+	//   <version latest="true" stable="true">1.2.2</version>
+	//   <version latest="false" stable="true">1.2.1</version>
+	//   <version latest="false" stable="true">1.2.0</version>
+	//   <version latest="false" stable="false">1.2.0-rc.0</version>
+	//   <version latest="false" stable="true">1.1.0</version>
+	// </versions-list>
+}
+
+func ExamplePretty_textFromByteSlice() {
+	data := []byte("Hello, World!1")
+
+	err := render.Pretty(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!1
+}
+
+func ExamplePretty_textFromString() {
+	data := "Hello, World!"
+
+	err := render.Pretty(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!
+}
+
+func ExamplePretty_textFromIOReader() {
+	var data io.Reader = strings.NewReader("Hello, World!!!1")
+
+	err := render.Pretty(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!!!1
+}
+
+func ExamplePretty_textFromWriterTo() {
+	// The Version struct has a WriteTo method which writes a string
+	// representation of a version to an io.Writer:
+	//
+	//	func (v *Version) WriteTo(w io.Writer) (int64, error) {
+	//		s := fmt.Sprintf(
+	//			"%s (stable: %t, latest: %t)", v.Version, v.Stable, v.Latest,
+	//		)
+	//		n, err := w.Write([]byte(s))
+	//
+	//		return int64(n), err
+	//	}
+
+	data := &Version{Version: "1.2.1", Stable: true, Latest: false}
+
+	err := render.Pretty(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1.2.1 (stable: true, latest: false)
+}
+
+func ExamplePretty_textFromStringer() {
+	// The User struct has a String method which returns a string representation
+	// of a user:
+	//
+	//	func (ol *OutputList) String() string {
+	//		buf := &strings.Builder{}
+	//
+	//		for _, ver := range ol.Versions {
+	//			if ol.Current == ver.Version {
+	//				buf.WriteString("* ")
+	//			} else {
+	//				buf.WriteString("  ")
+	//			}
+	//
+	//			buf.WriteString(ver.Version)
+	//			if !ver.Stable {
+	//				buf.WriteString(" (pre-release)")
+	//			}
+	//			if ver.Latest {
+	//				buf.WriteString(" (latest)")
+	//			}
+	//
+	//			buf.WriteByte('\n')
+	//		}
+	//
+	//		return buf.String()
+	//	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Pretty(os.Stdout, "text", data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// * 1.2.2 (latest)
+	//   1.2.1
+	//   1.2.0
+	//   1.2.0-rc.0 (pre-release)
+	//   1.1.0
+}

--- a/render_example_test.go
+++ b/render_example_test.go
@@ -1,253 +1,14 @@
 package render_test
 
 import (
-	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/jimeh/go-render"
 )
-
-func ExampleRender_json() {
-	type Version struct {
-		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
-	}
-
-	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
-		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
-
-		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
-	}
-
-	data := &OutputList{
-		Current: "1.2.2",
-		Versions: []Version{
-			{Version: "1.2.2", Stable: true, Latest: true},
-			{Version: "1.2.1", Stable: true},
-			{Version: "1.2.0", Stable: true},
-			{Version: "1.2.0-rc.0", Stable: false},
-			{Version: "1.1.0", Stable: true},
-		},
-	}
-
-	// Render the object to JSON.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "json", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// {
-	//   "current": "1.2.2",
-	//   "versions": [
-	//     {
-	//       "version": "1.2.2",
-	//       "latest": true,
-	//       "stable": true
-	//     },
-	//     {
-	//       "version": "1.2.1",
-	//       "latest": false,
-	//       "stable": true
-	//     },
-	//     {
-	//       "version": "1.2.0",
-	//       "latest": false,
-	//       "stable": true
-	//     },
-	//     {
-	//       "version": "1.2.0-rc.0",
-	//       "latest": false,
-	//       "stable": false
-	//     },
-	//     {
-	//       "version": "1.1.0",
-	//       "latest": false,
-	//       "stable": true
-	//     }
-	//   ]
-	// }
-}
-
-func ExampleRender_yaml() {
-	type Version struct {
-		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
-	}
-
-	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
-		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
-
-		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
-	}
-
-	data := &OutputList{
-		Current: "1.2.2",
-		Versions: []Version{
-			{Version: "1.2.2", Stable: true, Latest: true},
-			{Version: "1.2.1", Stable: true},
-			{Version: "1.2.0", Stable: true},
-			{Version: "1.2.0-rc.0", Stable: false},
-			{Version: "1.1.0", Stable: true},
-		},
-	}
-
-	// Render the object to YAML.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "yaml", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// current: 1.2.2
-	// versions:
-	//   - version: 1.2.2
-	//     latest: true
-	//     stable: true
-	//   - version: 1.2.1
-	//     latest: false
-	//     stable: true
-	//   - version: 1.2.0
-	//     latest: false
-	//     stable: true
-	//   - version: 1.2.0-rc.0
-	//     latest: false
-	//     stable: false
-	//   - version: 1.1.0
-	//     latest: false
-	//     stable: true
-}
-
-func ExampleRender_xml() {
-	type Version struct {
-		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
-	}
-
-	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
-		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
-
-		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
-	}
-
-	data := &OutputList{
-		Current: "1.2.2",
-		Versions: []Version{
-			{Version: "1.2.2", Stable: true, Latest: true},
-			{Version: "1.2.1", Stable: true},
-			{Version: "1.2.0", Stable: true},
-			{Version: "1.2.0-rc.0", Stable: false},
-			{Version: "1.1.0", Stable: true},
-		},
-	}
-
-	// Create a new renderer that supports XML in addition to the default JSON,
-	// Text, and YAML formats.
-	renderer := render.NewWith("json", "text", "xml", "yaml")
-
-	// Render the object to XML.
-	buf := &bytes.Buffer{}
-	err := renderer.Pretty(buf, "xml", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// <versions-list>
-	//   <current>1.2.2</current>
-	//   <version latest="true" stable="true">1.2.2</version>
-	//   <version latest="false" stable="true">1.2.1</version>
-	//   <version latest="false" stable="true">1.2.0</version>
-	//   <version latest="false" stable="false">1.2.0-rc.0</version>
-	//   <version latest="false" stable="true">1.1.0</version>
-	// </versions-list>
-}
-
-func ExampleRender_textFromByteSlice() {
-	data := []byte("Hello, World!1")
-
-	// Render the object to XML.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "text", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// Hello, World!1
-}
-
-func ExampleRender_textFromString() {
-	data := "Hello, World!"
-
-	// Render the object to XML.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "text", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// Hello, World!
-}
-
-func ExampleRender_textFromIOReader() {
-	var data io.Reader = strings.NewReader("Hello, World!!!1")
-
-	// Render the object to XML.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "text", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// Hello, World!!!1
-}
-
-func ExampleRender_textFromWriterTo() {
-	// The Version struct has a WriteTo method which writes a string
-	// representation of a version to an io.Writer:
-	//
-	//	func (v *Version) WriteTo(w io.Writer) (int64, error) {
-	//		s := fmt.Sprintf(
-	//			"%s (stable: %t, latest: %t)", v.Version, v.Stable, v.Latest,
-	//		)
-	//		n, err := w.Write([]byte(s))
-	//
-	//		return int64(n), err
-	//	}
-
-	data := &Version{Version: "1.2.1", Stable: true, Latest: false}
-
-	// Render the object to text.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "text", data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(buf.String())
-
-	// Output:
-	// 1.2.1 (stable: true, latest: false)
-}
 
 type Version struct {
 	Version string `json:"version" yaml:"version" xml:",chardata"`
@@ -295,7 +56,191 @@ func (ol *OutputList) String() string {
 	return buf.String()
 }
 
-func ExampleRender_textFromStringer() {
+//nolint:lll
+func ExampleRender_compactJSON() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Render(os.Stdout, "json", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// {"current":"1.2.2","versions":[{"version":"1.2.2","latest":true,"stable":true},{"version":"1.2.1","latest":false,"stable":true},{"version":"1.2.0","latest":false,"stable":true},{"version":"1.2.0-rc.0","latest":false,"stable":false},{"version":"1.1.0","latest":false,"stable":true}]}
+}
+
+func ExampleRender_compactYAML() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Render(os.Stdout, "yaml", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// current: 1.2.2
+	// versions:
+	//   - version: 1.2.2
+	//     latest: true
+	//     stable: true
+	//   - version: 1.2.1
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0-rc.0
+	//     latest: false
+	//     stable: false
+	//   - version: 1.1.0
+	//     latest: false
+	//     stable: true
+}
+
+//nolint:lll
+func ExampleRender_compactXML() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	// Create a new renderer that supports XML in addition to the default JSON,
+	// Text, and YAML formats.
+	renderer := render.NewWith("json", "text", "xml", "yaml")
+
+	err := renderer.Render(os.Stdout, "xml", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// <versions-list><current>1.2.2</current><version latest="true" stable="true">1.2.2</version><version latest="false" stable="true">1.2.1</version><version latest="false" stable="true">1.2.0</version><version latest="false" stable="false">1.2.0-rc.0</version><version latest="false" stable="true">1.1.0</version></versions-list>
+}
+
+func ExampleRender_compactTextFromByteSlice() {
+	data := []byte("Hello, World!1")
+
+	err := render.Render(os.Stdout, "text", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!1
+}
+
+func ExampleRender_compactTextFromString() {
+	data := "Hello, World!"
+
+	err := render.Render(os.Stdout, "text", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!
+}
+
+func ExampleRender_compactTextFromIOReader() {
+	var data io.Reader = strings.NewReader("Hello, World!!!1")
+
+	err := render.Render(os.Stdout, "text", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!!!1
+}
+
+func ExampleRender_compactTextFromWriterTo() {
+	// The Version struct has a WriteTo method which writes a string
+	// representation of a version to an io.Writer:
+	//
+	//	func (v *Version) WriteTo(w io.Writer) (int64, error) {
+	//		s := fmt.Sprintf(
+	//			"%s (stable: %t, latest: %t)", v.Version, v.Stable, v.Latest,
+	//		)
+	//		n, err := w.Write([]byte(s))
+	//
+	//		return int64(n), err
+	//	}
+
+	data := &Version{Version: "1.2.1", Stable: true, Latest: false}
+
+	err := render.Render(os.Stdout, "text", false, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1.2.1 (stable: true, latest: false)
+}
+
+func ExampleRender_compactTextFromStringer() {
 	// The User struct has a String method which returns a string representation
 	// of a user:
 	//
@@ -334,13 +279,280 @@ func ExampleRender_textFromStringer() {
 		},
 	}
 
-	// Render the object to XML.
-	buf := &bytes.Buffer{}
-	err := render.Pretty(buf, "text", data)
+	err := render.Render(os.Stdout, "text", false, data)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(buf.String())
+
+	// Output:
+	// * 1.2.2 (latest)
+	//   1.2.1
+	//   1.2.0
+	//   1.2.0-rc.0 (pre-release)
+	//   1.1.0
+}
+
+func ExampleRender_prettyJSON() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Render(os.Stdout, "json", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// {
+	//   "current": "1.2.2",
+	//   "versions": [
+	//     {
+	//       "version": "1.2.2",
+	//       "latest": true,
+	//       "stable": true
+	//     },
+	//     {
+	//       "version": "1.2.1",
+	//       "latest": false,
+	//       "stable": true
+	//     },
+	//     {
+	//       "version": "1.2.0",
+	//       "latest": false,
+	//       "stable": true
+	//     },
+	//     {
+	//       "version": "1.2.0-rc.0",
+	//       "latest": false,
+	//       "stable": false
+	//     },
+	//     {
+	//       "version": "1.1.0",
+	//       "latest": false,
+	//       "stable": true
+	//     }
+	//   ]
+	// }
+}
+
+func ExampleRender_prettyYAML() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Render(os.Stdout, "yaml", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// current: 1.2.2
+	// versions:
+	//   - version: 1.2.2
+	//     latest: true
+	//     stable: true
+	//   - version: 1.2.1
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0
+	//     latest: false
+	//     stable: true
+	//   - version: 1.2.0-rc.0
+	//     latest: false
+	//     stable: false
+	//   - version: 1.1.0
+	//     latest: false
+	//     stable: true
+}
+
+func ExampleRender_prettyXML() {
+	type Version struct {
+		Version string `json:"version" yaml:"version" xml:",chardata"`
+		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
+		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	}
+
+	type OutputList struct {
+		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
+
+		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
+	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	// Create a new renderer that supports XML in addition to the default JSON,
+	// Text, and YAML formats.
+	renderer := render.NewWith("json", "text", "xml", "yaml")
+
+	err := renderer.Render(os.Stdout, "xml", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// <versions-list>
+	//   <current>1.2.2</current>
+	//   <version latest="true" stable="true">1.2.2</version>
+	//   <version latest="false" stable="true">1.2.1</version>
+	//   <version latest="false" stable="true">1.2.0</version>
+	//   <version latest="false" stable="false">1.2.0-rc.0</version>
+	//   <version latest="false" stable="true">1.1.0</version>
+	// </versions-list>
+}
+
+func ExampleRender_prettyTextFromByteSlice() {
+	data := []byte("Hello, World!1")
+
+	err := render.Render(os.Stdout, "text", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!1
+}
+
+func ExampleRender_prettyTextFromString() {
+	data := "Hello, World!"
+
+	err := render.Render(os.Stdout, "text", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!
+}
+
+func ExampleRender_prettyTextFromIOReader() {
+	var data io.Reader = strings.NewReader("Hello, World!!!1")
+
+	err := render.Render(os.Stdout, "text", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Hello, World!!!1
+}
+
+func ExampleRender_prettyTextFromWriterTo() {
+	// The Version struct has a WriteTo method which writes a string
+	// representation of a version to an io.Writer:
+	//
+	//	func (v *Version) WriteTo(w io.Writer) (int64, error) {
+	//		s := fmt.Sprintf(
+	//			"%s (stable: %t, latest: %t)", v.Version, v.Stable, v.Latest,
+	//		)
+	//		n, err := w.Write([]byte(s))
+	//
+	//		return int64(n), err
+	//	}
+
+	data := &Version{Version: "1.2.1", Stable: true, Latest: false}
+
+	err := render.Render(os.Stdout, "text", true, data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1.2.1 (stable: true, latest: false)
+}
+
+func ExampleRender_prettyTextFromStringer() {
+	// The User struct has a String method which returns a string representation
+	// of a user:
+	//
+	//	func (ol *OutputList) String() string {
+	//		buf := &strings.Builder{}
+	//
+	//		for _, ver := range ol.Versions {
+	//			if ol.Current == ver.Version {
+	//				buf.WriteString("* ")
+	//			} else {
+	//				buf.WriteString("  ")
+	//			}
+	//
+	//			buf.WriteString(ver.Version)
+	//			if !ver.Stable {
+	//				buf.WriteString(" (pre-release)")
+	//			}
+	//			if ver.Latest {
+	//				buf.WriteString(" (latest)")
+	//			}
+	//
+	//			buf.WriteByte('\n')
+	//		}
+	//
+	//		return buf.String()
+	//	}
+
+	data := &OutputList{
+		Current: "1.2.2",
+		Versions: []Version{
+			{Version: "1.2.2", Stable: true, Latest: true},
+			{Version: "1.2.1", Stable: true},
+			{Version: "1.2.0", Stable: true},
+			{Version: "1.2.0-rc.0", Stable: false},
+			{Version: "1.1.0", Stable: true},
+		},
+	}
+
+	err := render.Render(os.Stdout, "text", true, data)
+	if err != nil {
+		panic(err)
+	}
 
 	// Output:
 	// * 1.2.2 (latest)


### PR DESCRIPTION
Previously all examples were associated with Render, but only used Pretty. Now
there are examples for each of the main package level functions.