### PR TITLE
fix(xml)!: correct spelling of XMLDefaultIndent

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -6,9 +6,9 @@ import (
 	"io"
 )
 
-// XMLDefualtIndent is the default indentation string used by XML instances when
+// XMLDefaultIndent is the default indentation string used by XML instances when
 // pretty rendering if no Indent value is set.
-var XMLDefualtIndent = "  "
+var XMLDefaultIndent = "  "
 
 // XML is a Renderer that marshals a value to XML.
 type XML struct {
@@ -17,7 +17,7 @@ type XML struct {
 	Prefix string
 
 	// Indent is the string added to each level of indentation when pretty
-	// rendering. If empty, XMLDefualtIndent be used.
+	// rendering. If empty, XMLDefaultIndent will be used.
 	Indent string
 }
 
@@ -43,7 +43,7 @@ func (x *XML) RenderPretty(w io.Writer, v any) error {
 	prefix := x.Prefix
 	indent := x.Indent
 	if indent == "" {
-		indent = XMLDefualtIndent
+		indent = XMLDefaultIndent
 	}
 
 	enc := xml.NewEncoder(w)


### PR DESCRIPTION
Fixes typo in variable name and references from 'XMLDefualtIndent' to 
'XMLDefaultIndent'. Updates the variable declaration and all references 
to maintain consistency throughout the XML renderer implementation.

BREAKING CHANGE: Rename `XMLDefualtIndent` to correctly spelled `XMLDefaultIndent`.