### PR TITLE
ci(release): move always-update to top-level

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,12 +1,12 @@
 {
   "initial-version": "0.0.1",
+  "always-update": true,
   "packages": {
     ".": {
       "release-type": "go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "always-update": true,
       "draft": false,
       "prerelease": false
     }


### PR DESCRIPTION
Package level definition seemed to not work.