### PR TITLE
chore: correct typos and align struct field tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The above assumes the following `Version` struct:
 ```go
 type Version struct {
     Version string `json:"version" yaml:"version" xml:",chardata"`
-    Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-    Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+    Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+    Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 }
 
 func (v *Version) String() string {

--- a/binary.go
+++ b/binary.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-// Binary can render values which implment the encoding.BinaryMarshaler
+// Binary can render values which implement the encoding.BinaryMarshaler
 // interface.
 type Binary struct{}
 
@@ -15,8 +15,8 @@ var (
 	_ FormatsHandler = (*Binary)(nil)
 )
 
-// Render writes result of calling MarshalBinary() on v. If v does not implment
-// encoding.BinaryMarshaler the ErrCannotRander error will be returned.
+// Render writes result of calling MarshalBinary() on v. If v does not implement
+// encoding.BinaryMarshaler the ErrCannotRender error will be returned.
 func (br *Binary) Render(w io.Writer, v any) error {
 	x, ok := v.(encoding.BinaryMarshaler)
 	if !ok {

--- a/compact_example_test.go
+++ b/compact_example_test.go
@@ -13,12 +13,12 @@ import (
 func ExampleCompact_json() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -47,12 +47,12 @@ func ExampleCompact_json() {
 func ExampleCompact_yaml() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -98,12 +98,12 @@ func ExampleCompact_yaml() {
 func ExampleCompact_xml() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`

--- a/interfaces.go
+++ b/interfaces.go
@@ -3,7 +3,7 @@ package render
 import "io"
 
 // Handler interface is for single format renderers, which can only render a
-// single format. It is the basis of the multi-format support offerred by the
+// single format. It is the basis of the multi-format support offered by the
 // render package.
 type Handler interface {
 	// Render writes v into w in the format that the Handler supports.

--- a/pretty_example_test.go
+++ b/pretty_example_test.go
@@ -12,12 +12,12 @@ import (
 func ExamplePretty_json() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -75,12 +75,12 @@ func ExamplePretty_json() {
 func ExamplePretty_yaml() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -125,12 +125,12 @@ func ExamplePretty_yaml() {
 func ExamplePretty_xml() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`

--- a/render.go
+++ b/render.go
@@ -1,4 +1,4 @@
-// Package render provides a simple and flexible solutio to render a value to a
+// Package render provides a simple and flexible solution to render a value to a
 // io.Writer using different formats based on a format string argument.
 //
 // It is designed around using a custom type/struct to render your output.

--- a/render_example_test.go
+++ b/render_example_test.go
@@ -12,8 +12,8 @@ import (
 
 type Version struct {
 	Version string `json:"version" yaml:"version" xml:",chardata"`
-	Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-	Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+	Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+	Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 }
 
 func (v *Version) WriteTo(w io.Writer) (int64, error) {
@@ -26,7 +26,7 @@ func (v *Version) WriteTo(w io.Writer) (int64, error) {
 }
 
 type OutputList struct {
-	Current  string    `json:"current" yaml:"current" xml:"current"`
+	Current  string    `json:"current"  yaml:"current"  xml:"current"`
 	Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 	XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -60,12 +60,12 @@ func (ol *OutputList) String() string {
 func ExampleRender_compactJSON() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -94,12 +94,12 @@ func ExampleRender_compactJSON() {
 func ExampleRender_compactYAML() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -145,12 +145,12 @@ func ExampleRender_compactYAML() {
 func ExampleRender_compactXML() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -295,12 +295,12 @@ func ExampleRender_compactTextFromStringer() {
 func ExampleRender_prettyJSON() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -358,12 +358,12 @@ func ExampleRender_prettyJSON() {
 func ExampleRender_prettyYAML() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`
@@ -408,12 +408,12 @@ func ExampleRender_prettyYAML() {
 func ExampleRender_prettyXML() {
 	type Version struct {
 		Version string `json:"version" yaml:"version" xml:",chardata"`
-		Latest  bool   `json:"latest" yaml:"latest" xml:"latest,attr"`
-		Stable  bool   `json:"stable" yaml:"stable" xml:"stable,attr"`
+		Latest  bool   `json:"latest"  yaml:"latest"  xml:"latest,attr"`
+		Stable  bool   `json:"stable"  yaml:"stable"  xml:"stable,attr"`
 	}
 
 	type OutputList struct {
-		Current  string    `json:"current" yaml:"current" xml:"current"`
+		Current  string    `json:"current"  yaml:"current"  xml:"current"`
 		Versions []Version `json:"versions" yaml:"versions" xml:"version"`
 
 		XMLName xml.Name `json:"-" yaml:"-" xml:"versions-list"`

--- a/render_test.go
+++ b/render_test.go
@@ -132,7 +132,7 @@ type renderFormatTestCase struct {
 }
 
 // "binary" format.
-var binaryFormattestCases = []renderFormatTestCase{
+var binaryFormatTestCases = []renderFormatTestCase{
 	{
 		name:    "with binary marshaler",
 		formats: []string{"binary", "bin"},

--- a/renderer.go
+++ b/renderer.go
@@ -105,7 +105,7 @@ func (r *Renderer) Pretty(w io.Writer, format string, v any) error {
 }
 
 // NewWith creates a new Renderer with the formats given, if they have handlers
-// in the currener Renderer. It essentially allows to restrict a Renderer to a
+// in the current Renderer. It essentially allows to restrict a Renderer to a
 // only a sub-set of supported formats.
 func (r *Renderer) NewWith(formats ...string) *Renderer {
 	handlers := make(map[string]Handler, len(formats))

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -112,13 +112,13 @@ func TestRenderer_Add(t *testing.T) {
 			want:    []string{"tackle"},
 		},
 		{
-			name:    "hander with Formats",
+			name:    "handler with Formats",
 			format:  "hackle",
 			handler: &mockFormatsHandler{formats: []string{"hackle"}},
 			want:    []string{"hackle"},
 		},
 		{
-			name:    "hander with alias formats",
+			name:    "handler with alias formats",
 			format:  "hackle",
 			handler: &mockFormatsHandler{formats: []string{"hackle", "hack"}},
 			want:    []string{"hackle", "hack"},
@@ -471,7 +471,7 @@ func TestRenderer_Pretty(t *testing.T) {
 
 func TestRenderer_RenderAllFormats(t *testing.T) {
 	tests := []renderFormatTestCase{}
-	tests = append(tests, binaryFormattestCases...)
+	tests = append(tests, binaryFormatTestCases...)
 	tests = append(tests, jsonFormatTestCases...)
 	tests = append(tests, textFormatTestCases...)
 	tests = append(tests, xmlFormatTestCases...)
@@ -540,7 +540,7 @@ func TestRenderer_RenderAllFormats(t *testing.T) {
 
 func TestRenderer_CompactAllFormats(t *testing.T) {
 	tests := []renderFormatTestCase{}
-	tests = append(tests, binaryFormattestCases...)
+	tests = append(tests, binaryFormatTestCases...)
 	tests = append(tests, jsonFormatTestCases...)
 	tests = append(tests, textFormatTestCases...)
 	tests = append(tests, xmlFormatTestCases...)
@@ -602,7 +602,7 @@ func TestRenderer_CompactAllFormats(t *testing.T) {
 
 func TestRenderer_PrettyAllFormats(t *testing.T) {
 	tests := []renderFormatTestCase{}
-	tests = append(tests, binaryFormattestCases...)
+	tests = append(tests, binaryFormatTestCases...)
 	tests = append(tests, jsonFormatTestCases...)
 	tests = append(tests, textFormatTestCases...)
 	tests = append(tests, xmlFormatTestCases...)


### PR DESCRIPTION
Fixes typos in package documentation and variable names. Aligns 
struct field tags in examples and tests for better readability.