### PR TITLE
fix(makefile): update golangci-lint import path to v2 module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endef
 $(eval $(call tool,godoc,golang.org/x/tools/cmd/godoc@latest))
 $(eval $(call tool,gofumpt,mvdan.cc/gofumpt@latest))
 $(eval $(call tool,goimports,golang.org/x/tools/cmd/goimports@latest))
-$(eval $(call tool,golangci-lint,github.com/golangci/golangci-lint/cmd/golangci-lint@v2.1.6))
+$(eval $(call tool,golangci-lint,github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1))
 $(eval $(call tool,gomod,github.com/Helcaraxan/gomod@latest))
 
 .PHONY: tools


### PR DESCRIPTION
Use correct import path for golangci-lint v2 so that `make lint` works.